### PR TITLE
Add functional tests running option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,11 @@ gulp.task('typescript', function(){
   gulp.src(config.typescript.input)
   .pipe(tsc())
   .pipe(gulp.dest("Scripts"))
-  .pipe(intern({config:"tests/intern", workingDir: 'Scripts' }));
+  .pipe(intern({
+    config:"tests/intern",
+    runType: "client", // defaults to "client", use "runner" if you want to run functional tests
+    workingDir: 'Scripts'
+  }));
 
 });
 

--- a/index.js
+++ b/index.js
@@ -4,9 +4,22 @@ var spawn = require('child_process').spawn;
 var gutil = require('gulp-util');
 
 module.exports = function(opt) {
+  var testRunner;
   opt = opt || {};
   opt.config = opt.config || 'tests/config';
   opt.workingDir = opt.workingDir || process.cwd();
+  opt.runType = opt.runType || 'client';
+  switch(opt.runType) {
+  case 'client':
+    testRunner = 'intern-client.js';
+    break;
+  case 'runner':
+    testRunner = 'intern-runner.js';
+    break;
+  default:
+    throw new Error('"runType" option can be only "client" or "runner"');
+  }
+
 
 
   function bufferContents(file) {
@@ -14,7 +27,7 @@ module.exports = function(opt) {
   }
 
   function endStream() {
-    var internPath = [process.cwd(), 'node_modules', 'intern', 'bin', 'intern-client.js'].join(path.sep),
+    var internPath = [process.cwd(), 'node_modules', 'intern', 'bin', testRunner].join(path.sep),
       child = spawn('node', [internPath, 'config=' + opt.config], {cwd: opt.workingDir}),
       stdout = '',
       stderr = '';

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var path = require('path');
 var through = require('through');
 var spawn = require('child_process').spawn;
 var gutil = require('gulp-util');
+var PLUGIN_NAME = 'gulp-intern';
 
 module.exports = function(opt) {
   var testRunner;
@@ -17,7 +18,7 @@ module.exports = function(opt) {
     testRunner = 'intern-runner.js';
     break;
   default:
-    throw new Error('"runType" option can be only "client" or "runner"');
+    throw new gutil.PluginError(PLUGIN_NAME, '"runType" option can be only "client" or "runner"');
   }
 
 
@@ -48,7 +49,7 @@ module.exports = function(opt) {
 
     child.on('close', function(code) {
       if(code !== 0) {
-        new gutil.PluginError('gulp-intern', 'Tests failed');
+        new gutil.PluginError(PLUGIN_NAME, 'Tests failed');
       }
     });
 


### PR DESCRIPTION
Hello
gulp-intern is useful plugin but it is using intern-client.js which does not run
functional tests, so I forked repo and added possibility to use intern-runner.js instead of intern-client.js.
To run intern-runner.js "runType" option with value "runner" can be added to intern function.
I chose "runType" and "runner" because the same are used in grunt.

I hope this will be useful.
Sławek Dróżdż
