### PR TITLE
Fix problem with interaction with selenium-standalone

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,14 +47,13 @@ module.exports = function(opt) {
         gutil.beep();
     });
 
+    var self = this;
     child.on('close', function(code) {
+      self.emit('end');
       if(code !== 0) {
         new gutil.PluginError(PLUGIN_NAME, 'Tests failed');
       }
     });
-
-
-    this.emit('end');
   }
 
 


### PR DESCRIPTION
I am using selenium-standalone to start/stop selenium around invoking intern. In the current version, the intern task terminates before the tests are finished. As a result, selenium is killed before the tests are completed. 

The problem is solved by emitting the 'end' event when the forked intern process terminates.
